### PR TITLE
Refactored config objects with go-flags

### DIFF
--- a/benchmarks/examplebench/main.go
+++ b/benchmarks/examplebench/main.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/Shopify/mybench"
+	"github.com/jessevdk/go-flags"
 )
 
 type ExampleBenchmarkConfig struct {
 	*mybench.BenchmarkAppConfig
-	InitialNumRows int64
+	InitialNumRows int64 `long:"numrows" description:"the number of rows to load into the database" default:"1000000"`
 }
 
 func NewSimpleTable(idGen *mybench.AutoIncrementGenerator) mybench.Table {
@@ -34,8 +33,10 @@ func main() {
 	config := ExampleBenchmarkConfig{
 		BenchmarkAppConfig: mybench.NewBenchmarkAppConfig(),
 	}
-	flag.Int64Var(&config.InitialNumRows, "numrows", 1000000, "the number of rows to load into the database")
-	flag.Parse()
+	_, err := flags.Parse(&config)
+	if err != nil {
+		panic(err)
+	}
 
 	app, err := mybench.NewBenchmarkApp("ExampleBench", config, setupBenchmark, runLoader)
 	if err != nil {

--- a/benchmarks/selfbench/main.go
+++ b/benchmarks/selfbench/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"flag"
-	"time"
-
 	"github.com/Shopify/mybench"
+	"github.com/jessevdk/go-flags"
 )
 
 func main() {
@@ -16,11 +14,10 @@ func main() {
 	config.BenchmarkAppConfig.DatabaseConfig.NoConnection = true
 	config.BenchmarkAppConfig.DatabaseConfig.Host = "no-host"
 
-	flag.IntVar(&config.Concurrency, "concurrency", 1, "the number of workers to use")
-	flag.Float64Var(&config.EventRatePerWorker, "event-rate-per-worker", 100.0, "the number of events per second per worker")
-	flag.Float64Var(&config.OuterLoopRate, "outer-loop-rate", 50.0, "the outer loop rate of the DiscretizedLooper")
-	flag.DurationVar(&config.SpinTime, "spin-time", 5*time.Millisecond, "the amount of time to waste in each Event() call")
-	flag.Parse()
+	_, err := flags.Parse(&config)
+	if err != nil {
+		panic(err)
+	}
 
 	app, err := mybench.NewBenchmarkApp("SelfBench", config, setupBenchmark, runLoader)
 	if err != nil {

--- a/benchmarks/selfbench/selfbench.go
+++ b/benchmarks/selfbench/selfbench.go
@@ -11,10 +11,11 @@ import (
 
 type SelfBenchConfig struct {
 	*mybench.BenchmarkAppConfig
-	EventRatePerWorker float64
-	Concurrency        int
-	OuterLoopRate      float64
-	SpinTime           time.Duration
+
+	EventRatePerWorker float64       `long:"event-rate-per-worker" description:"the number of workers to use" default:"100.0"`
+	Concurrency        int           `long:"concurrency" description:"the number of workers to use" default:"1"`
+	OuterLoopRate      float64       `long:"outer-loop-rate" description:"the outer loop rate of the looper" default:"50.0"`
+	SpinTime           time.Duration `long:"spin-time" description:"the amount of time to waste in each Event() call" default:"5ms"`
 }
 
 type SelfBench struct {

--- a/connection.go
+++ b/connection.go
@@ -10,11 +10,11 @@ import (
 // (without connection pooling).
 type DatabaseConfig struct {
 	// TODO: Unix socket
-	Host     string
-	Port     int
-	User     string
-	Pass     string
-	Database string
+	Host     string `short:"H" long:"host" description:"host of the database instance" group:"database"`
+	Port     int    `short:"P" long:"port" description:"port of the database instance" default:"3306" group:"database"`
+	User     string `short:"u" long:"user" description:"username for the database" default:"root" group:"database"`
+	Pass     string `short:"p" long:"pass" description:"password for the database" default:"" group:"database"`
+	Database string `short:"d" long:"db" description:"name of the database schema (if applicable)" default:"mybench" group:"database"`
 
 	// If this is set, a connection will not be established. This is useful for
 	// non-database-related tests such as selfbench.
@@ -53,4 +53,12 @@ func (c DatabaseConfig) Connection() (*Connection, error) {
 
 type Connection struct {
 	*client.Conn
+}
+
+func (c *Connection) Close() error {
+	if c.Conn == nil {
+		return nil // This happens if NoConnection is true
+	}
+
+	return c.Conn.Close()
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2
 	github.com/go-mysql-org/go-mysql v1.6.0
 	github.com/google/uuid v1.3.0
+	github.com/jessevdk/go-flags v1.5.0
 	github.com/mattn/go-sqlite3 v1.14.13
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -113,6 +115,7 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This makes command line flags more easily defined as the go-flags library and can be more easily parsed, which simplifies the code.

Further, if we want to eventually construct mybench runs via alternative ways to specify configurations (like via a file, or via a RPC from some sort of distributed mybench), using this library will give us that flexibility.

The downside is that all the benchmarks needs to change slightly (mostly removing code that manually sets up the flags), and how we run mybench needs to change slightly (from a single dash to two dashes).