### PR TITLE
General code cleanup to make things easier

### DIFF
--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -11,7 +11,7 @@ type InsertSimpleTable struct {
 }
 
 func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
-	var workloadInterface mybench.WorkloadInterface[mybench.NoContextData] = &InsertSimpleTable{
+	workloadInterface := &InsertSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "InsertSimpleTable",
 			DatabaseConfig: exampleBench.BenchmarkConfig.DatabaseConfig,
@@ -23,7 +23,7 @@ func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[mybench.NoContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ type UpdateSimpleTable struct {
 }
 
 func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
-	var workloadInterface mybench.WorkloadInterface[mybench.NoContextData] = &UpdateSimpleTable{
+	workloadInterface := &UpdateSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "UpdateSimpleTable",
 			DatabaseConfig: exampleBench.BenchmarkConfig.DatabaseConfig,
@@ -60,7 +60,7 @@ func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[mybench.NoContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -6,6 +6,7 @@ import (
 
 type InsertSimpleTable struct {
 	mybench.WorkloadConfig
+	mybench.NoContextData
 	table mybench.Table
 }
 
@@ -30,10 +31,6 @@ func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 	return workload
 }
 
-func (r *InsertSimpleTable) Config() mybench.WorkloadConfig {
-	return r.WorkloadConfig
-}
-
 func (r *InsertSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextData]) error {
 	query := "INSERT INTO example_table (id, data) VALUES (?, ?)"
 	args := make([]interface{}, 2)
@@ -44,12 +41,9 @@ func (r *InsertSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextDat
 	return err
 }
 
-func (r *InsertSimpleTable) NewContextData(conn *mybench.Connection) (mybench.NoContextData, error) {
-	return mybench.NewNoContextData()
-}
-
 type UpdateSimpleTable struct {
 	mybench.WorkloadConfig
+	mybench.NoContextData
 	table mybench.Table
 }
 
@@ -74,10 +68,6 @@ func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 	return workload
 }
 
-func (r *UpdateSimpleTable) Config() mybench.WorkloadConfig {
-	return r.WorkloadConfig
-}
-
 func (r *UpdateSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextData]) error {
 	query := "UPDATE example_table SET data = ? WHERE id = ?"
 	args := make([]interface{}, 2)
@@ -86,8 +76,4 @@ func (r *UpdateSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextDat
 
 	_, err := ctx.Conn.Execute(query, args...)
 	return err
-}
-
-func (r *UpdateSimpleTable) NewContextData(conn *mybench.Connection) (mybench.NoContextData, error) {
-	return mybench.NewNoContextData()
 }

--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -13,7 +13,7 @@ type BulkSelectIndexed struct {
 
 func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64) mybench.AbstractWorkload {
 	eventRate = eventRate * config.Multiplier
-	var workloadInterface mybench.WorkloadInterface[MicroBenchContextData] = &BulkSelectIndexed{
+	workloadInterface := &BulkSelectIndexed{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "BulkSelectIndexed",
 			DatabaseConfig: config.DatabaseConfig,
@@ -24,7 +24,7 @@ func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table,
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -32,10 +32,6 @@ func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table,
 	return workload
 }
 
-func (c *BulkSelectIndexed) Config() mybench.WorkloadConfig {
-	return c.WorkloadConfig
-}
-
 func (c *BulkSelectIndexed) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {
 	args := []interface{}{
 		c.table.Generate(ctx.Rand, "idx2"),

--- a/benchmarks/microbench/bulk_select_indexed_filter.go
+++ b/benchmarks/microbench/bulk_select_indexed_filter.go
@@ -34,10 +34,6 @@ func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.
 	return workload
 }
 
-func (c *BulkSelectIndexedFilter) Config() mybench.WorkloadConfig {
-	return c.WorkloadConfig
-}
-
 func (c *BulkSelectIndexedFilter) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {
 	args := []interface{}{
 		c.table.Generate(ctx.Rand, "idx2"),

--- a/benchmarks/microbench/bulk_select_indexed_filter.go
+++ b/benchmarks/microbench/bulk_select_indexed_filter.go
@@ -14,7 +14,7 @@ type BulkSelectIndexedFilter struct {
 
 func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, filterField string) mybench.AbstractWorkload {
 	eventRate = eventRate * config.Multiplier
-	var workloadInterface mybench.WorkloadInterface[MicroBenchContextData] = &BulkSelectIndexedFilter{
+	workloadInterface := &BulkSelectIndexedFilter{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "BulkSelectIndexedFilter_" + filterField,
 			DatabaseConfig: config.DatabaseConfig,
@@ -26,7 +26,7 @@ func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.
 		filterField: filterField,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -34,10 +34,6 @@ func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.T
 	return workload
 }
 
-func (c *BulkSelectIndexedOrder) Config() mybench.WorkloadConfig {
-	return c.WorkloadConfig
-}
-
 func (c *BulkSelectIndexedOrder) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {
 	args := []interface{}{
 		c.table.Generate(ctx.Rand, "idx2"),

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -14,7 +14,7 @@ type BulkSelectIndexedOrder struct {
 
 func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, orderField string) mybench.AbstractWorkload {
 	eventRate = eventRate * config.Multiplier
-	var workloadInterface mybench.WorkloadInterface[MicroBenchContextData] = &BulkSelectIndexedOrder{
+	workloadInterface := &BulkSelectIndexedOrder{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "BulkSelectIndexedOrdered_" + orderField,
 			DatabaseConfig: config.DatabaseConfig,
@@ -26,7 +26,7 @@ func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.T
 		orderField: orderField,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -37,10 +37,6 @@ func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, event
 	return workload
 }
 
-func (c *PointSelect) Config() mybench.WorkloadConfig {
-	return c.WorkloadConfig
-}
-
 func (c *PointSelect) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {
 	args := make([]interface{}, c.batchSize)
 	for i := 0; i < c.batchSize; i++ {

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -17,7 +17,7 @@ type PointSelect struct {
 
 func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, batchSize int) mybench.AbstractWorkload {
 	eventRate = eventRate * config.Multiplier
-	var workloadInterface mybench.WorkloadInterface[MicroBenchContextData] = &PointSelect{
+	workloadInterface := &PointSelect{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:           "PointSelect_" + strconv.Itoa(batchSize),
 			DatabaseConfig: config.DatabaseConfig,
@@ -29,7 +29,7 @@ func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, event
 		batchSize: batchSize,
 	}
 
-	workload, err := mybench.NewWorkload(workloadInterface)
+	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A few things were done:

- Make `WorkloadConfig` implement the `Config` method. This means all structs that embeds `WorkloadConfig` will automatically implement the `Config` method that's required by the `WorkloadInterface`.
- Make `NoContextData` implement the `NewContextData` method so that any struct that embeds `NoContextData` will automatically implement the method as required by `WorkloadInterface`.
- Changed the definition of `WorkloadInterface` in the example benchmarks to be slightly less verbose, by selecting the templated function manually instead of relying on inference. 