### PR TITLE
Eliminate event rate multiplier and create explicit event rate and concurrency arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Having all this data in hundreds of independent Goroutines (`BenchmarkWorkers`) 
 Run a benchmark
 ---------------
 
-- Shopify orders benchmark: `make examplebench && build/examplebench -host mysql-1 -user sys.admin_rw -pass hunter2 -bench -multiplier 30`
+- Shopify orders benchmark: `make examplebench && build/examplebench -host mysql-1 -user sys.admin_rw -pass hunter2 -bench -eventrate 3000`
   - Change the host
-  - Change the multiplier. The base rate is only 100 event/s so turn it up!
+  - Change the event rate. The base rate is only 1000 event/s so turn it up!
 - Go to https://localhost:8005 to see the monitoring web UI.
 
 Write your own benchmark

--- a/benchmark_app.go
+++ b/benchmark_app.go
@@ -18,9 +18,10 @@ type BenchmarkConfig struct {
 	Load  bool
 
 	LoadConcurrency int
+	Concurrency     int
 	HttpPort        int
 	Duration        time.Duration
-	Multiplier      float64
+	EventRate       float64
 	LogFile         string
 	LogTable        string
 	Note            string
@@ -39,10 +40,11 @@ func NewBenchmarkConfig() *BenchmarkConfig {
 	flag.BoolVar(&config.Bench, "bench", false, "run the benchmark")
 	flag.IntVar(&config.HttpPort, "httpport", 8005, "port of the monitoring UI")
 	flag.DurationVar(&config.Duration, "duration", 0, "duration of the benchmark")
-	flag.Float64Var(&config.Multiplier, "multiplier", 1.0, "multiplier of the benchmark")
+	flag.Float64Var(&config.EventRate, "eventrate", 1000, "target event rate of the benchmark in requests per second")
 	flag.StringVar(&config.LogFile, "log", "data.sqlite", "the path to the log file")
 	flag.StringVar(&config.LogTable, "logtable", "", "the table name in the sqlite file to record to (default: based on the start time in RFC3399)")
 	flag.StringVar(&config.Note, "note", "", "a note to include in the meta table entry for this run")
+	flag.IntVar(&config.Concurrency, "concurrency", 200, "the concurrency to use during the benchmark (default: 200)")
 
 	flag.IntVar(&config.LoadConcurrency, "load-concurrency", 16, "the concurrency to use during the load")
 

--- a/benchmark_app.go
+++ b/benchmark_app.go
@@ -12,23 +12,29 @@ import (
 )
 
 type BenchmarkConfig struct {
+	Bench    bool
+	Load     bool
+	Duration time.Duration
+	LogFile  string
+	LogTable string
+	Note     string
+
 	DatabaseConfig DatabaseConfig
 
-	Bench bool
-	Load  bool
+	RateControlConfig RateControlConfig
 
-	LoadConcurrency int
-	Concurrency     int
-	HttpPort        int
-	Duration        time.Duration
-	EventRate       float64
-	LogFile         string
-	LogTable        string
-	Note            string
+	HttpPort int
 }
 
 func NewBenchmarkConfig() *BenchmarkConfig {
 	config := &BenchmarkConfig{}
+
+	flag.BoolVar(&config.Load, "load", false, "load the data before the benchmark")
+	flag.BoolVar(&config.Bench, "bench", false, "run the benchmark")
+	flag.DurationVar(&config.Duration, "duration", 0, "duration of the benchmark")
+	flag.StringVar(&config.LogFile, "log", "data.sqlite", "the path to the log file")
+	flag.StringVar(&config.LogTable, "logtable", "", "the table name in the sqlite file to record to (default: based on the start time in RFC3399)")
+	flag.StringVar(&config.Note, "note", "", "a note to include in the meta table entry for this run")
 
 	flag.StringVar(&config.DatabaseConfig.Host, "host", "", "database host name")
 	flag.IntVar(&config.DatabaseConfig.Port, "port", 3306, "database port (default: 3306)")
@@ -36,17 +42,10 @@ func NewBenchmarkConfig() *BenchmarkConfig {
 	flag.StringVar(&config.DatabaseConfig.Pass, "pass", "", "database password (default: empty)")
 	flag.StringVar(&config.DatabaseConfig.Database, "db", "mybench", "database name (default: mybench)")
 
-	flag.BoolVar(&config.Load, "load", false, "load the data before the benchmark")
-	flag.BoolVar(&config.Bench, "bench", false, "run the benchmark")
-	flag.IntVar(&config.HttpPort, "httpport", 8005, "port of the monitoring UI")
-	flag.DurationVar(&config.Duration, "duration", 0, "duration of the benchmark")
-	flag.Float64Var(&config.EventRate, "eventrate", 1000, "target event rate of the benchmark in requests per second")
-	flag.StringVar(&config.LogFile, "log", "data.sqlite", "the path to the log file")
-	flag.StringVar(&config.LogTable, "logtable", "", "the table name in the sqlite file to record to (default: based on the start time in RFC3399)")
-	flag.StringVar(&config.Note, "note", "", "a note to include in the meta table entry for this run")
-	flag.IntVar(&config.Concurrency, "concurrency", 200, "the concurrency to use during the benchmark (default: 200)")
+	flag.Float64Var(&config.RateControlConfig.EventRate, "eventrate", 1000, "target event rate of the benchmark in requests per second")
+	flag.IntVar(&config.RateControlConfig.Concurrency, "concurrency", 100, "the concurrency to use during the benchmark (default: 100)")
 
-	flag.IntVar(&config.LoadConcurrency, "load-concurrency", 16, "the concurrency to use during the load")
+	flag.IntVar(&config.HttpPort, "httpport", 8005, "port of the monitoring UI")
 
 	return config
 }

--- a/benchmark_worker.go
+++ b/benchmark_worker.go
@@ -22,7 +22,7 @@ type BenchmarkWorker[ContextDataT any] struct {
 
 func NewBenchmarkWorker[ContextDataT any](workloadIface WorkloadInterface[ContextDataT]) (*BenchmarkWorker[ContextDataT], error) {
 	config := workloadIface.Config()
-	conn, err := config.DatabaseConfig.Connection()
+	conn, err := config.BenchmarkConfig.DatabaseConfig.Connection()
 	if err != nil {
 		return nil, err
 	}

--- a/benchmark_worker.go
+++ b/benchmark_worker.go
@@ -22,7 +22,7 @@ type BenchmarkWorker[ContextDataT any] struct {
 
 func NewBenchmarkWorker[ContextDataT any](workloadIface WorkloadInterface[ContextDataT]) (*BenchmarkWorker[ContextDataT], error) {
 	config := workloadIface.Config()
-	conn, err := config.BenchmarkConfig.DatabaseConfig.Connection()
+	conn, err := config.DatabaseConfig.Connection()
 	if err != nil {
 		return nil, err
 	}

--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -13,11 +13,9 @@ type InsertSimpleTable struct {
 func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
 	workloadInterface := &InsertSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "InsertSimpleTable",
-			DatabaseConfig: exampleBench.BenchmarkConfig.DatabaseConfig,
-			RateControl: mybench.RateControlConfig{
-				EventRate: 50 * exampleBench.BenchmarkConfig.Multiplier,
-			},
+			Name:             "InsertSimpleTable",
+			BenchmarkConfig:  exampleBench.BenchmarkConfig,
+			WorkloadPctScale: 50,
 		}),
 
 		table: table,
@@ -50,11 +48,9 @@ type UpdateSimpleTable struct {
 func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
 	workloadInterface := &UpdateSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "UpdateSimpleTable",
-			DatabaseConfig: exampleBench.BenchmarkConfig.DatabaseConfig,
-			RateControl: mybench.RateControlConfig{
-				EventRate: 50 * exampleBench.BenchmarkConfig.Multiplier,
-			},
+			Name:             "UpdateSimpleTable",
+			BenchmarkConfig:  exampleBench.BenchmarkConfig,
+			WorkloadPctScale: 50,
 		}),
 
 		table: table,

--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -14,7 +14,8 @@ func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 	workloadInterface := &InsertSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:             "InsertSimpleTable",
-			BenchmarkConfig:  exampleBench.BenchmarkConfig,
+			DatabaseConfig:   exampleBench.BenchmarkConfig.DatabaseConfig,
+			RateControl:      exampleBench.BenchmarkConfig.RateControlConfig,
 			WorkloadPctScale: 50,
 		}),
 
@@ -49,7 +50,8 @@ func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybenc
 	workloadInterface := &UpdateSimpleTable{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
 			Name:             "UpdateSimpleTable",
-			BenchmarkConfig:  exampleBench.BenchmarkConfig,
+			DatabaseConfig:   exampleBench.BenchmarkConfig.DatabaseConfig,
+			RateControl:      exampleBench.BenchmarkConfig.RateControlConfig,
 			WorkloadPctScale: 50,
 		}),
 

--- a/benchmarks/microbench/README.md
+++ b/benchmarks/microbench/README.md
@@ -2,6 +2,7 @@
 ============
 
 `microbench` is a suite of queries designed to test the performance of different parts of MySQL. It is based on common query patterns that we observe in production, but also from a first-principled approach.
+Note that the `eventrate` command-line argument is ignored for `microbench` -- see the individual arguments listed in `main()`.
 
 Table model
 -----------

--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -14,8 +14,8 @@ type BulkSelectIndexed struct {
 func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexed{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:            "BulkSelectIndexed",
-			BenchmarkConfig: config,
+			Name:           "BulkSelectIndexed",
+			DatabaseConfig: config.DatabaseConfig,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -12,11 +12,10 @@ type BulkSelectIndexed struct {
 }
 
 func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64) mybench.AbstractWorkload {
-	eventRate = eventRate * config.Multiplier
 	workloadInterface := &BulkSelectIndexed{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "BulkSelectIndexed",
-			DatabaseConfig: config.DatabaseConfig,
+			Name:            "BulkSelectIndexed",
+			BenchmarkConfig: config,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/bulk_select_indexed_filter.go
+++ b/benchmarks/microbench/bulk_select_indexed_filter.go
@@ -13,11 +13,10 @@ type BulkSelectIndexedFilter struct {
 }
 
 func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, filterField string) mybench.AbstractWorkload {
-	eventRate = eventRate * config.Multiplier
 	workloadInterface := &BulkSelectIndexedFilter{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "BulkSelectIndexedFilter_" + filterField,
-			DatabaseConfig: config.DatabaseConfig,
+			Name:            "BulkSelectIndexedFilter_" + filterField,
+			BenchmarkConfig: config,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/bulk_select_indexed_filter.go
+++ b/benchmarks/microbench/bulk_select_indexed_filter.go
@@ -15,8 +15,8 @@ type BulkSelectIndexedFilter struct {
 func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, filterField string) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexedFilter{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:            "BulkSelectIndexedFilter_" + filterField,
-			BenchmarkConfig: config,
+			Name:           "BulkSelectIndexedFilter_" + filterField,
+			DatabaseConfig: config.DatabaseConfig,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -15,8 +15,8 @@ type BulkSelectIndexedOrder struct {
 func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, orderField string) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexedOrder{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:            "BulkSelectIndexedOrdered_" + orderField,
-			BenchmarkConfig: config,
+			Name:           "BulkSelectIndexedOrdered_" + orderField,
+			DatabaseConfig: config.DatabaseConfig,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -13,11 +13,10 @@ type BulkSelectIndexedOrder struct {
 }
 
 func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, orderField string) mybench.AbstractWorkload {
-	eventRate = eventRate * config.Multiplier
 	workloadInterface := &BulkSelectIndexedOrder{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "BulkSelectIndexedOrdered_" + orderField,
-			DatabaseConfig: config.DatabaseConfig,
+			Name:            "BulkSelectIndexedOrdered_" + orderField,
+			BenchmarkConfig: config,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/main.go
+++ b/benchmarks/microbench/main.go
@@ -145,7 +145,7 @@ func (b MicroBench) RunLoader() error {
 		b.DatabaseConfig,
 		b.InitialNumRows,
 		500,
-		b.BenchmarkConfig.LoadConcurrency,
+		b.RateControlConfig.Concurrency,
 	)
 	return nil
 }

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -16,11 +16,10 @@ type PointSelect struct {
 }
 
 func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, batchSize int) mybench.AbstractWorkload {
-	eventRate = eventRate * config.Multiplier
 	workloadInterface := &PointSelect{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:           "PointSelect_" + strconv.Itoa(batchSize),
-			DatabaseConfig: config.DatabaseConfig,
+			Name:            "PointSelect_" + strconv.Itoa(batchSize),
+			BenchmarkConfig: config,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -18,8 +18,8 @@ type PointSelect struct {
 func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, eventRate float64, batchSize int) mybench.AbstractWorkload {
 	workloadInterface := &PointSelect{
 		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:            "PointSelect_" + strconv.Itoa(batchSize),
-			BenchmarkConfig: config,
+			Name:           "PointSelect_" + strconv.Itoa(batchSize),
+			DatabaseConfig: config.DatabaseConfig,
 			RateControl: mybench.RateControlConfig{
 				EventRate: eventRate,
 			},


### PR DESCRIPTION
Rather than having a `multiplier` arg that implicitly sets event rate and concurrency, these have been made explicit:
- `eventrate` arg, default 1000
- `concurrency` arg, default 200

Both of the corresponding settings (along with `connections`, to be added later) are subject to scaling according to the new `WorkloadPctScale` field in `WorkloadConfig`.
