### PR TITLE
Made rate control and database config not a part of workload config

### DIFF
--- a/benchmarks/examplebench/main.go
+++ b/benchmarks/examplebench/main.go
@@ -56,8 +56,8 @@ func (b ExampleBench) Workloads() ([]mybench.AbstractWorkload, error) {
 	table := NewSimpleTable(idGen)
 
 	return []mybench.AbstractWorkload{
-		NewInsertSimpleTable(b, table),
-		NewUpdateSimpleTable(b, table),
+		NewInsertSimpleTable(table),
+		NewUpdateSimpleTable(table),
 	}, nil
 }
 

--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -10,24 +10,17 @@ type InsertSimpleTable struct {
 	table mybench.Table
 }
 
-func NewInsertSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
+func NewInsertSimpleTable(table mybench.Table) mybench.AbstractWorkload {
 	workloadInterface := &InsertSimpleTable{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "InsertSimpleTable",
-			DatabaseConfig:    exampleBench.BenchmarkConfig.DatabaseConfig,
-			RateControlConfig: exampleBench.BenchmarkConfig.RateControlConfig,
-			WorkloadScale:     0.5,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "InsertSimpleTable",
+			WorkloadScale: 0.5,
+		},
 
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload[mybench.NoContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[mybench.NoContextData](workloadInterface)
 }
 
 func (r *InsertSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextData]) error {
@@ -46,24 +39,17 @@ type UpdateSimpleTable struct {
 	table mybench.Table
 }
 
-func NewUpdateSimpleTable(exampleBench ExampleBench, table mybench.Table) mybench.AbstractWorkload {
+func NewUpdateSimpleTable(table mybench.Table) mybench.AbstractWorkload {
 	workloadInterface := &UpdateSimpleTable{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "UpdateSimpleTable",
-			DatabaseConfig:    exampleBench.BenchmarkConfig.DatabaseConfig,
-			RateControlConfig: exampleBench.BenchmarkConfig.RateControlConfig,
-			WorkloadScale:     0.5,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "UpdateSimpleTable",
+			WorkloadScale: 0.5,
+		},
 
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload[mybench.NoContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[mybench.NoContextData](workloadInterface)
 }
 
 func (r *UpdateSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextData]) error {

--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -11,23 +11,16 @@ type BulkSelectIndexed struct {
 	table *mybench.Table
 }
 
-func NewBulkSelectIndexed(config *mybench.BenchmarkConfig, table *mybench.Table, rateScale float64) mybench.AbstractWorkload {
+func NewBulkSelectIndexed(table *mybench.Table, rateScale float64) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexed{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "BulkSelectIndexed",
-			DatabaseConfig:    config.DatabaseConfig,
-			RateControlConfig: config.RateControlConfig,
-			WorkloadScale:     rateScale,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "BulkSelectIndexed",
+			WorkloadScale: rateScale,
+		},
 		table: table,
 	}
 
-	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 }
 
 func (c *BulkSelectIndexed) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {

--- a/benchmarks/microbench/bulk_select_indexed_filter.go
+++ b/benchmarks/microbench/bulk_select_indexed_filter.go
@@ -12,24 +12,17 @@ type BulkSelectIndexedFilter struct {
 	filterField string
 }
 
-func NewBulkSelectIndexedFilter(config *mybench.BenchmarkConfig, table *mybench.Table, rateScale float64, filterField string) mybench.AbstractWorkload {
+func NewBulkSelectIndexedFilter(table *mybench.Table, rateScale float64, filterField string) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexedFilter{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "BulkSelectIndexedFilter_" + filterField,
-			DatabaseConfig:    config.DatabaseConfig,
-			RateControlConfig: config.RateControlConfig,
-			WorkloadScale:     rateScale,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "BulkSelectIndexedFilter_" + filterField,
+			WorkloadScale: rateScale,
+		},
 		table:       table,
 		filterField: filterField,
 	}
 
-	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 }
 
 func (c *BulkSelectIndexedFilter) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -12,24 +12,17 @@ type BulkSelectIndexedOrder struct {
 	orderField string
 }
 
-func NewBulkSelectIndexedOrder(config *mybench.BenchmarkConfig, table *mybench.Table, rateScale float64, orderField string) mybench.AbstractWorkload {
+func NewBulkSelectIndexedOrder(table *mybench.Table, rateScale float64, orderField string) mybench.AbstractWorkload {
 	workloadInterface := &BulkSelectIndexedOrder{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "BulkSelectIndexedOrdered_" + orderField,
-			DatabaseConfig:    config.DatabaseConfig,
-			RateControlConfig: config.RateControlConfig,
-			WorkloadScale:     rateScale,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "BulkSelectIndexedOrdered_" + orderField,
+			WorkloadScale: rateScale,
+		},
 		table:      table,
 		orderField: orderField,
 	}
 
-	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 }
 
 func (c *BulkSelectIndexedOrder) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {

--- a/benchmarks/microbench/main.go
+++ b/benchmarks/microbench/main.go
@@ -106,27 +106,27 @@ func (b MicroBench) Workloads() ([]mybench.AbstractWorkload, error) {
 
 	workloads := []mybench.AbstractWorkload{}
 	if b.BulkSelectIndexedRateScale > 0 {
-		workloads = append(workloads, NewBulkSelectIndexed(b.BenchmarkConfig, &table, b.BulkSelectIndexedRateScale))
+		workloads = append(workloads, NewBulkSelectIndexed(&table, b.BulkSelectIndexedRateScale))
 	}
 
 	if b.BulkSelectIndexedOrderIndexedRateScale > 0 {
-		workloads = append(workloads, NewBulkSelectIndexedOrder(b.BenchmarkConfig, &table, b.BulkSelectIndexedOrderIndexedRateScale, "idx1"))
+		workloads = append(workloads, NewBulkSelectIndexedOrder(&table, b.BulkSelectIndexedOrderIndexedRateScale, "idx1"))
 	}
 
 	if b.BulkSelectIndexedOrderNonIndexedRateScale > 0 {
-		workloads = append(workloads, NewBulkSelectIndexedOrder(b.BenchmarkConfig, &table, b.BulkSelectIndexedOrderNonIndexedRateScale, "data1"))
+		workloads = append(workloads, NewBulkSelectIndexedOrder(&table, b.BulkSelectIndexedOrderNonIndexedRateScale, "data1"))
 	}
 
 	if b.BulkSelectIndexedFilterRateScale > 0 {
-		workloads = append(workloads, NewBulkSelectIndexedFilter(b.BenchmarkConfig, &table, b.BulkSelectIndexedFilterRateScale, "b"))
+		workloads = append(workloads, NewBulkSelectIndexedFilter(&table, b.BulkSelectIndexedFilterRateScale, "b"))
 	}
 
 	if b.PointSelectRateScale > 0 {
-		workloads = append(workloads, NewPointSelect(b.BenchmarkConfig, &table, b.PointSelectRateScale, 1))
+		workloads = append(workloads, NewPointSelect(&table, b.PointSelectRateScale, 1))
 	}
 
 	if b.BatchPointSelectRateScale > 0 {
-		workloads = append(workloads, NewPointSelect(b.BenchmarkConfig, &table, b.BatchPointSelectRateScale, 200))
+		workloads = append(workloads, NewPointSelect(&table, b.BatchPointSelectRateScale, 200))
 	}
 
 	return workloads, nil

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -15,24 +15,17 @@ type PointSelect struct {
 	batchSize int
 }
 
-func NewPointSelect(config *mybench.BenchmarkConfig, table *mybench.Table, rateScale float64, batchSize int) mybench.AbstractWorkload {
+func NewPointSelect(table *mybench.Table, rateScale float64, batchSize int) mybench.AbstractWorkload {
 	workloadInterface := &PointSelect{
-		WorkloadConfig: mybench.NewWorkloadConfigWithDefaults(mybench.WorkloadConfig{
-			Name:              "PointSelect_" + strconv.Itoa(batchSize),
-			DatabaseConfig:    config.DatabaseConfig,
-			RateControlConfig: config.RateControlConfig,
-			WorkloadScale:     rateScale,
-		}),
+		WorkloadConfig: mybench.WorkloadConfig{
+			Name:          "PointSelect_" + strconv.Itoa(batchSize),
+			WorkloadScale: rateScale,
+		},
 		table:     table,
 		batchSize: batchSize,
 	}
 
-	workload, err := mybench.NewWorkload[MicroBenchContextData](workloadInterface)
-	if err != nil {
-		panic(err)
-	}
-
-	return workload
+	return mybench.NewWorkload[MicroBenchContextData](workloadInterface)
 }
 
 func (c *PointSelect) Event(ctx mybench.WorkerContext[MicroBenchContextData]) error {

--- a/data_logger.go
+++ b/data_logger.go
@@ -289,7 +289,7 @@ func (d *DataLogger) collectData() *DataSnapshot {
 	histograms := make(map[string][]*ExtendedHdrHistogram)
 	for _, workload := range d.Benchmark.workloads {
 		config := workload.Config()
-		histograms[config.Name] = make([]*ExtendedHdrHistogram, config.RateControlConfig.Concurrency)
+		histograms[config.Name] = make([]*ExtendedHdrHistogram, workload.RateControlConfig().Concurrency)
 	}
 
 	// Anonymous function declaration likely needs an allocation too (to capture
@@ -342,11 +342,11 @@ func (d *DataLogger) collectData() *DataSnapshot {
 				config.Visualization.LatencyHistMax,
 				config.Visualization.LatencyHistSize,
 			),
-			DesiredRate: config.RateControlConfig.EventRate,
+			DesiredRate: workload.RateControlConfig().EventRate,
 		}
 
 		allWorkloadsMergedHistogram.Merge(perWorkloadMergedHistogram)
-		dataSnapshot.AllWorkloadData.DesiredRate += config.RateControlConfig.EventRate
+		dataSnapshot.AllWorkloadData.DesiredRate += workload.RateControlConfig().EventRate
 	}
 
 	dataSnapshot.AllWorkloadData.IntervalData = allWorkloadsMergedHistogram.IntervalData(now, 1, 300000, 1000) // TODO: configurable


### PR DESCRIPTION
This makes it easier to specify the workload. It also prevents a situation where the `-eventrate` flags are ignored if the RateControlConfig is not set on the WorkloadConfig.