### PR TITLE
Fix nil pointer when running large amt of workers

### DIFF
--- a/benchmark_worker.go
+++ b/benchmark_worker.go
@@ -2,6 +2,7 @@ package mybench
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -72,10 +73,11 @@ func NewBenchmarkWorker[ContextDataT any](workloadIface WorkloadInterface[Contex
 	return worker, nil
 }
 
-func (b *BenchmarkWorker[ContextDataT]) Run(ctx context.Context, startTime time.Time, databaseConfig DatabaseConfig, rateControlConfig RateControlConfig) error {
+func (b *BenchmarkWorker[ContextDataT]) Run(ctx context.Context, workerInitializationWg *sync.WaitGroup, startTime time.Time, databaseConfig DatabaseConfig, rateControlConfig RateControlConfig) error {
 	// TODO: kind of weird that the conn is opened in NewBenchmarkWorker but closed here. This should maybe be fixed
 	defer b.context.Conn.Close()
 	b.onlineHist = NewOnlineHistogram(startTime)
+	workerInitializationWg.Done()
 	return b.looper.Run(ctx)
 }
 


### PR DESCRIPTION
This is not a great fix, and lacks some comments. The problem is that it takes a long time to start a large number of workers (and to allocate the HDR Histogram data structure for all the workers). The data logger could be scheduled to run before all workers have fully initialized with the OnlineHistogram object fully populated. This can cause the first data swap (after 1 second, by default) to fail with a nil pointer exception.

The reason this is not a great fix is because the whole code is super spaghetti, as follows:

- The `mybench.NewWorkload` method partially initializes the `Workload` struct. This is called from `WorkloadInterface.Workloads()` which is defined by the user. This method is called by `mybench.Run` early on in the code.
  - The workload at this point is not finished all its initialization.
- Immediately after the above code is called, `Benchmark.Start` is called, which loops through all the workloads and calls `FinishInitialization` This further initializes the `Workload` struct with the database and rate control config, which could not be determined during the call to `NewWorkload` (not technically true, but the `WorkloadInterface.Workloads` method doesn't accept that).
  - Contrary to the name suggests, this doesn't actually finish initialize the workload. The workers themselves are not created yet (maybe they can be).
  - More crucially, since the worker is not been created, the OnlineHistogram object also is not created at this point.
- Immediately after `FinishInitialization`, the code calls `Workload.Run` in a goroutine, which internally calls `Worker.Run` in yet another goroutine.
  - The `OnlineHistogram` is created in the `Worker.Run` method.
- What this means is that the `OnlineHistogram` objects are being created in goroutines independent of the main thread (which is running `benchmark.Start`).
- After spawning all the goroutines, the `Benchmark.Start` code immediately runs the data logger in its own goroutine. The data logger wakes up after 1 second to swap the data from the `OnlineHistogram`s.
  - If there are a lot of workers, it is possible the `OnlineHistogram` hasn't been created yet as that worker's goroutine hasn't been scheduled yet. This causes a nil pointer exception in the data logger.

Anyways such a long description means the code design is broken and should be fixed. The current fix is a temporary hack that make the code work. Improvements to this should come in a follow-up PR.