### PR TITLE
Fix UniformLengthStringGenerator for static length

### DIFF
--- a/data_generators.go
+++ b/data_generators.go
@@ -380,7 +380,10 @@ func (g *UniformLengthStringGenerator) Generate(r *Rand) interface{} {
 }
 
 func (g *UniformLengthStringGenerator) GenerateTyped(r *Rand) string {
-	length := r.UniformInt(int64(g.minLength), int64(g.maxLength))
+	length := int64(g.maxLength)
+	if g.minLength < g.maxLength {
+		length = r.UniformInt(int64(g.minLength), int64(g.maxLength))
+	}
 	buf := make([]byte, length)
 	for i := int64(0); i < length; i++ {
 		buf[i] = characters[r.Intn(len(characters))]

--- a/data_generators_test.go
+++ b/data_generators_test.go
@@ -240,7 +240,7 @@ func TestHistogramCardinalityStringGenerator(t *testing.T) {
 	})
 }
 
-func TestUniformLengthStringGenerator(t *testing.T) {
+func TestVariableLengthUniformStringsGenerator(t *testing.T) {
 	const minLength, maxLength = 3, 6
 	gen := NewUniformLengthStringGenerator(minLength, maxLength)
 	r := newRandForTest()
@@ -260,6 +260,30 @@ func TestUniformLengthStringGenerator(t *testing.T) {
 			3: 33020,
 			4: 33586,
 			5: 33394,
+		}
+
+		require.Equal(t, expectedLengthCount, lengthCount)
+	})
+}
+
+func TestUniformLengthStringsGenerator(t *testing.T) {
+	const minLength, maxLength = 3, 3
+	gen := NewUniformLengthStringGenerator(minLength, maxLength)
+	r := newRandForTest()
+
+	t.Run("Generate", func(t *testing.T) {
+		const n = 100_000
+		lengthCount := map[int]int{}
+
+		for i := 0; i < n; i++ {
+			v, ok := gen.Generate(r).(string)
+			require.True(t, ok, "should be generating string but is not")
+			count := lengthCount[len(v)]
+			lengthCount[len(v)] = count + 1
+		}
+
+		expectedLengthCount := map[int]int{
+			3: 100_000,
 		}
 
 		require.Equal(t, expectedLengthCount, lengthCount)


### PR DESCRIPTION

UniformLengthStringGenerator with a matching min/max would panic with
panic: invalid argument to Int63n