### PR TITLE
Added high-resolution tracing via `runtime/trace` to better debug occasional high latency events

### DIFF
--- a/benchmarks/examplebench/workloads.go
+++ b/benchmarks/examplebench/workloads.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"runtime/trace"
+
 	"github.com/Shopify/mybench"
 )
 
@@ -58,6 +60,7 @@ func (r *UpdateSimpleTable) Event(ctx mybench.WorkerContext[mybench.NoContextDat
 	args[0] = r.table.Generate(ctx.Rand, "data")
 	args[1] = r.table.SampleFromExisting(ctx.Rand, "id")
 
+	defer trace.StartRegion(ctx.TraceCtx, "UpdateSimpleTableQuery").End()
 	_, err := ctx.Conn.Execute(query, args...)
 	return err
 }

--- a/examples/looper/main.go
+++ b/examples/looper/main.go
@@ -41,7 +41,7 @@ func runLoop(v int64) []mybench.OuterLoopStat {
 	// loop which will significantly increase the size of the logs.
 	stats := make([]mybench.OuterLoopStat, 0, loopDuration*outerLoopRate*50)
 
-	looper.Event = func() error {
+	looper.Event = func(context.Context) error {
 		computePrime(v)
 		return nil
 	}

--- a/looper.go
+++ b/looper.go
@@ -74,109 +74,117 @@ func (l *DiscretizedLooper) Run(ctx context.Context) error {
 		default:
 		}
 
-		lastWakeupTime := nextWakeupTime
-		actualWakeupTime := time.Now()
+		err := func() error {
+			lastWakeupTime := nextWakeupTime
+			actualWakeupTime := time.Now()
 
-		// Calculate the event batch size for this period
-		// ==============================================
-		//
-		// Each outer loop period contain enough time for the event to trigger N
-		// times. The code calculates value of N:
+			// Calculate the event batch size for this period
+			// ==============================================
+			//
+			// Each outer loop period contain enough time for the event to trigger N
+			// times. The code calculates value of N:
 
-		// First, calculate the next wakeup time based on the outer loop rate. There
-		// are a few possibilities:
-		//
-		// 1. The current time is actually already past the next wakeup time. This
-		//    means the loop is very behind. N = 1 in this case. At the end of the
-		//    loop, no sleep is needed as we need to catch up as fast as possible
-		//    (may not be possible at all, but the system should try nonetheless).
-		// 2. The nextExpectedEventTime is actually in the next period.
-		// 3. The current time is before the next wakeup time, which means we can
-		//    try to compute N. N is computed by simulating the events forward,
-		//    until the nextExpectedEventTime is past the nextWakeupTime.
-		//    -  There is a special case where the nextExpectedEventTime is in the
-		//       past (possibly because the loop is falling behind). In this case,
-		//       we are still going to generate a large N. If that causes the loop
-		//       to fall further behind, the next iterations will eventually lead to
-		//       case 1.
-		nextWakeupTime = nextWakeupTime.Add(time.Duration(1.0 / l.OuterLoopRate * 1000000000))
-		if actualWakeupTime.Sub(nextWakeupTime) >= 0 {
-			// This case is when the looper is really behind, as the next wake up time
-			// is behind the current actual wake up time.. so we just execute as
-			// fast as possible until we catch up (which might be never). The next
-			// wake up time is set to the next event time, which _should_ be in the
-			// past, which means no sleeping (unless the Poisson distribution sample
-			// something significantly in the future, which then it sleeps)
-			eventBatchSize = 1
-			nextWakeupTime = nextExpectedEventTime
-			nextExpectedEventTime = nextExpectedEventTime.Add(l.interArrivalDuration())
-		} else if nextExpectedEventTime.Sub(nextWakeupTime) >= 0 {
-			// In this case, the next expected event time is in the next period, so we
-			// just skip this period without executing any events.
-			eventBatchSize = 0
-		} else {
-			// nextExpectedEventTime - lastWakeupTime - actualWakeupTime - nextWakeupTime
-			// lastWakeupTime - nextExpectedEventTime - actualWakeupTime - nextWakeupTime
-			// lastWakeupTime - actualWakeupTime - nextExpectedEventTime - nextWakeupTime
-			eventBatchSize = 0 // TODO: Should this be 0 or 1? Is there
-			for nextExpectedEventTime.Sub(nextWakeupTime) < 0 {
+			// First, calculate the next wakeup time based on the outer loop rate. There
+			// are a few possibilities:
+			//
+			// 1. The current time is actually already past the next wakeup time. This
+			//    means the loop is very behind. N = 1 in this case. At the end of the
+			//    loop, no sleep is needed as we need to catch up as fast as possible
+			//    (may not be possible at all, but the system should try nonetheless).
+			// 2. The nextExpectedEventTime is actually in the next period.
+			// 3. The current time is before the next wakeup time, which means we can
+			//    try to compute N. N is computed by simulating the events forward,
+			//    until the nextExpectedEventTime is past the nextWakeupTime.
+			//    -  There is a special case where the nextExpectedEventTime is in the
+			//       past (possibly because the loop is falling behind). In this case,
+			//       we are still going to generate a large N. If that causes the loop
+			//       to fall further behind, the next iterations will eventually lead to
+			//       case 1.
+			nextWakeupTime = nextWakeupTime.Add(time.Duration(1.0 / l.OuterLoopRate * 1000000000))
+			if actualWakeupTime.Sub(nextWakeupTime) >= 0 {
+				// This case is when the looper is really behind, as the next wake up time
+				// is behind the current actual wake up time.. so we just execute as
+				// fast as possible until we catch up (which might be never). The next
+				// wake up time is set to the next event time, which _should_ be in the
+				// past, which means no sleeping (unless the Poisson distribution sample
+				// something significantly in the future, which then it sleeps)
+				eventBatchSize = 1
+				nextWakeupTime = nextExpectedEventTime
 				nextExpectedEventTime = nextExpectedEventTime.Add(l.interArrivalDuration())
-				eventBatchSize++
-			}
-		}
-
-		// Running the events
-		// ==================
-		//
-		// In an naive implementation, you want to call Event on every loop
-		// iteration and wake up at some point later as dictated by the desired loop
-		// rate. This does not work because Golang (and non-real-time Linux) cannot
-		// keep a constant loop at rates above 100Hz consistently (in other words,
-		// requesting for a sleep of 1ms does not mean the goroutine will sleep 1ms.
-		// It will usually sleep a lot more than 1ms).
-		//
-		// Instead, the idea is to batch multiple Event() calls in a single loop
-		// iteration. Since there's no sleep in an Event, then the desired rate
-		// higher than 100Hz can be achieved. Effectively, this discretizes time
-		// into windows due to the limitations imposed by Golang and Linux.
-		for i := int64(0); i < eventBatchSize; i++ {
-			var eventStart time.Time
-			if l.TraceEvent != nil {
-				eventStart = time.Now()
+			} else if nextExpectedEventTime.Sub(nextWakeupTime) >= 0 {
+				// In this case, the next expected event time is in the next period, so we
+				// just skip this period without executing any events.
+				eventBatchSize = 0
+			} else {
+				// nextExpectedEventTime - lastWakeupTime - actualWakeupTime - nextWakeupTime
+				// lastWakeupTime - nextExpectedEventTime - actualWakeupTime - nextWakeupTime
+				// lastWakeupTime - actualWakeupTime - nextExpectedEventTime - nextWakeupTime
+				eventBatchSize = 0 // TODO: Should this be 0 or 1? Is there
+				for nextExpectedEventTime.Sub(nextWakeupTime) < 0 {
+					nextExpectedEventTime = nextExpectedEventTime.Add(l.interArrivalDuration())
+					eventBatchSize++
+				}
 			}
 
-			err := l.Event()
-			if err != nil {
-				return err
+			// Running the events
+			// ==================
+			//
+			// In an naive implementation, you want to call Event on every loop
+			// iteration and wake up at some point later as dictated by the desired loop
+			// rate. This does not work because Golang (and non-real-time Linux) cannot
+			// keep a constant loop at rates above 100Hz consistently (in other words,
+			// requesting for a sleep of 1ms does not mean the goroutine will sleep 1ms.
+			// It will usually sleep a lot more than 1ms).
+			//
+			// Instead, the idea is to batch multiple Event() calls in a single loop
+			// iteration. Since there's no sleep in an Event, then the desired rate
+			// higher than 100Hz can be achieved. Effectively, this discretizes time
+			// into windows due to the limitations imposed by Golang and Linux.
+			for i := int64(0); i < eventBatchSize; i++ {
+				var eventStart time.Time
+				if l.TraceEvent != nil {
+					eventStart = time.Now()
+				}
+
+				err := l.Event()
+				if err != nil {
+					return err
+				}
+
+				if l.TraceEvent != nil {
+					l.TraceEvent(EventStat{
+						TimeTaken: time.Since(eventStart),
+					})
+				}
+			}
+			executedNumberOfEvents += eventBatchSize
+			eventsEnd := time.Now()
+
+			if l.TraceOuterLoop != nil {
+				outerLoopStat := OuterLoopStat{
+					DesiredWakeupTime:        lastWakeupTime,
+					ActualWakeupTime:         actualWakeupTime,
+					EventBatchSize:           eventBatchSize,
+					EventsEnd:                eventsEnd,
+					EventsLatency:            eventsEnd.Sub(actualWakeupTime),
+					NextDesiredWakeupTime:    nextWakeupTime,
+					NextExpectedEventTime:    nextExpectedEventTime,
+					CumulativeNumberOfEvents: executedNumberOfEvents,
+				}
+				l.TraceOuterLoop(outerLoopStat)
 			}
 
-			if l.TraceEvent != nil {
-				l.TraceEvent(EventStat{
-					TimeTaken: time.Since(eventStart),
-				})
+			now := time.Now()
+			delta := nextWakeupTime.Sub(now)
+			if delta > time.Duration(0) { // May want to have a positive threshold, but requires looking at the top logic calculating the batch size
+				time.Sleep(delta)
 			}
-		}
-		executedNumberOfEvents += eventBatchSize
-		eventsEnd := time.Now()
 
-		if l.TraceOuterLoop != nil {
-			outerLoopStat := OuterLoopStat{
-				DesiredWakeupTime:        lastWakeupTime,
-				ActualWakeupTime:         actualWakeupTime,
-				EventBatchSize:           eventBatchSize,
-				EventsEnd:                eventsEnd,
-				EventsLatency:            eventsEnd.Sub(actualWakeupTime),
-				NextDesiredWakeupTime:    nextWakeupTime,
-				NextExpectedEventTime:    nextExpectedEventTime,
-				CumulativeNumberOfEvents: executedNumberOfEvents,
-			}
-			l.TraceOuterLoop(outerLoopStat)
-		}
+			return nil
+		}()
 
-		now := time.Now()
-		delta := nextWakeupTime.Sub(now)
-		if delta > time.Duration(0) { // May want to have a positive threshold, but requires looking at the top logic calculating the batch size
-			time.Sleep(delta)
+		if err != nil {
+			return err
 		}
 	}
 }

--- a/looper_test.go
+++ b/looper_test.go
@@ -158,7 +158,7 @@ func TestLooperNoBackPressure(t *testing.T) {
 	// Don't ant to allocate in the loop, so we allocate plenty of space
 	stats := make([]OuterLoopStat, 0, int(looper.OuterLoopRate*float64(numEvents)/looper.EventRate*10))
 
-	looper.Event = func() error {
+	looper.Event = func(context.Context) error {
 		sleeper.Sleep(1000)
 		return nil
 	}
@@ -231,7 +231,7 @@ func TestLooperSignificantBackPressure(t *testing.T) {
 	// Don't ant to allocate in the loop, so we allocate plenty of space
 	stats := make([]OuterLoopStat, 0, int(looper.OuterLoopRate*float64(numEvents)/looper.EventRate*10))
 
-	looper.Event = func() error {
+	looper.Event = func(context.Context) error {
 		// Want 5 seconds with 100 events means 20 events per seconds or 1/20
 		// seconds per event This means there's significant back pressure and the
 		// looper should switch to the busy loop style, which means the final loop


### PR DESCRIPTION
When I'm running certain benchmarks, I've noticed periodic spikes of very high latency like this:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/338100/212996043-f2fa765e-6a01-4fee-99e8-8d83f00cde99.png">

There's no easy way to debug this on the mybench side as mybench only presents data in aggregate. While it may be possible to get to the source of these problems the database's logging and tracing features (such as MySQL's slow query log), it is still handy to have a way to visualize this information directly in mybench. Luckily, Golang's standard library has this feature built into it via the [`runtime/trace`](https://pkg.go.dev/runtime/trace) library.

This PR introduces tracing for every event, and also allows users to create trace their own `Event` functions, see `examplebench` for an example of this. 

To review this PR, I would recommend only looking at the second commit. The first commit introduces an anonymous function which unfortunately reindented all the code.

# A short tutorial on how to use this feature

If you want to investigate individual `Event` calls and their timing, perform the following few steps:

1. Build and run mybench normally.
2. While mybench is running, run `curl -o trace.out "http://localhost:6060/debug/pprof/trace?seconds=10"`. You may need to adjust the hostname if you're running mybench remotely, or setup the appropriate port forward as necessary.
3. Then run `go tool trace trace.out`, which should open a webpage like this in the browser:

<img width="937" alt="image" src="https://user-images.githubusercontent.com/338100/212997019-6031d669-e113-4de4-9056-17a558700ddc.png">

4. Scroll down this page until you see **User-defined tasks and regions**:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/338100/212997124-09a0df32-0ad8-43f5-a8ce-4d7096f827a8.png">

5. Both `User-defined task` and `User-defined region` are useful.

## `User-defined task`

Mybench currently defines a number of trace tasks:

- `LogData` and `CollectData`, which you don't need to worry about as they are related to the data logger performance and usually should not impact the performance of the `Event()` function.
- `OuterLoopIteration{WorkloadName}`: each workload get its own task, to more easily identify the latencies for the different workloads. Each task is a whole outer loop iteration, which normally should execute at 50 Hz (20ms per task). Within each outer loop iteration, `Event` is called multiple times.

Within each task, we define a number of "regions". Each `OuterLoopIteration` task should consist of multiple `Event{WorkloadName}` regions followed by a single `Sleep` region.

Clicking into `User-defined task` will give you a page that looks like this:

<img width="851" alt="image" src="https://user-images.githubusercontent.com/338100/212999384-71194496-0dff-477c-be98-268924484685.png">

In the above example, there is a workload called `InsertOrder`. Most of the outer loop iteration executes between 15-20ms, which we expect as the default outer loop rate is 50 Hz. However, there are a few events where the outer loop took >100ms, which is abnormal. Clicking on the link on `158ms` gives us this page:

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/338100/212999507-3902c4bf-4754-41a6-af08-1b06e88c1ef9.png">

We can see that this task run through the `EventInsertOrder` region multiple times and `Sleep` region once per task. 0s is spent in GC during the task(`GC: 0s`). Most of the time is spent in one of the `EventInsertOrder` region in this case.

To get more detail on what's blocking, we have to go into the `User-defined region` view for some reason (which is also why the `Event` region has the workload name in it, so we can more easily filter for it in that view).

## `User-defined region`

Going back to the main page and clicking on `User-defined region` will give you this page:

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/338100/213000085-957ed478-71d2-4051-a4e4-afff2b6a0db7.png">

We can see the 8 `EventInsertOrder` region that took more than 158ms. Clicking on `158ms` gives the following screen:

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/338100/213000230-d2eec1a6-b085-4f2e-8e45-fc76e5bff0a8.png">

We can see most of the time, according to the Golang runtime, is spent in network wait, which suggests the server being benchmarked is responsible (could be the benchmark host networking stack as well, but this is a good start). We can see that executing time, sync block (time spent waiting for mutex) and scheduler wait (time spent waiting for the golang goroutine scheduler) is minimal, which we expect. If these numbers are high (non zero for syncblock), it would suggest that something is wrong with mybench's code. After looking at slow query log, it was determined that these spikes comes from MySQL.