### PR TITLE
Add connection support for CLIENT_MULTI_STATEMENTS

### DIFF
--- a/benchmark_app.go
+++ b/benchmark_app.go
@@ -43,6 +43,7 @@ func NewBenchmarkConfig() *BenchmarkConfig {
 	flag.StringVar(&config.DatabaseConfig.Pass, "pass", "", "database password (default: empty)")
 	flag.StringVar(&config.DatabaseConfig.Database, "db", "mybench", "database name (default: mybench)")
 	flag.IntVar(&config.DatabaseConfig.ConnectionMultiplier, "connectionmultiplier", 1, "number of database connections per parallel worker (default: 1)")
+	flag.BoolVar(&config.DatabaseConfig.ClientMultiStatements, "clientmultistatements", false, "Enable support for CLIENT_MULTI_STATEMENTS on the connection")
 
 	flag.Float64Var(&config.RateControlConfig.EventRate, "eventrate", 1000, "target event rate of the benchmark in requests per second (default: 1000)")
 	flag.IntVar(&config.RateControlConfig.Concurrency, "concurrency", 0, "number of parallel workers to use during the benchmark (default: auto)")


### PR DESCRIPTION
This allows benchmarks to use the ExecuteMultiple() method to send multiple statements to MySQL.

https://github.com/go-mysql-org/go-mysql/blob/f8546806eee3bcb9692350f670bd456d8bf1537c/client/conn.go#L221-L233

Without this calling ExecuteMultiple will fail with the misleading errror:
```ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near....```