### PR TITLE
Escape all db values

### DIFF
--- a/benchmarks/microbench/bulk_select_indexed.go
+++ b/benchmarks/microbench/bulk_select_indexed.go
@@ -36,7 +36,7 @@ func (c *BulkSelectIndexed) NewContextData(conn *mybench.Connection) (MicroBench
 	var err error
 	contextData := MicroBenchContextData{}
 
-	query := fmt.Sprintf("SELECT * FROM %s WHERE idx2 = ?", c.table.Name)
+	query := fmt.Sprintf("SELECT * FROM `%s` WHERE idx2 = ?", c.table.Name)
 	contextData.Statement, err = conn.Prepare(query)
 	return contextData, err
 }

--- a/benchmarks/microbench/bulk_select_indexed_order.go
+++ b/benchmarks/microbench/bulk_select_indexed_order.go
@@ -38,7 +38,7 @@ func (c *BulkSelectIndexedOrder) NewContextData(conn *mybench.Connection) (Micro
 	var err error
 	contextData := MicroBenchContextData{}
 
-	query := fmt.Sprintf("SELECT * FROM %s WHERE idx2 = ? ORDER BY %s", c.table.Name, c.orderField)
+	query := fmt.Sprintf("SELECT * FROM `%s` WHERE idx2 = ? ORDER BY `%s`", c.table.Name, c.orderField)
 	contextData.Statement, err = conn.Prepare(query)
 	return contextData, err
 }

--- a/benchmarks/microbench/point_select.go
+++ b/benchmarks/microbench/point_select.go
@@ -51,7 +51,7 @@ func (c *PointSelect) NewContextData(conn *mybench.Connection) (MicroBenchContex
 	var err error
 	contextData := MicroBenchContextData{}
 
-	query := fmt.Sprintf("SELECT * FROM %s WHERE %s", c.table.Name, clause)
+	query := fmt.Sprintf("SELECT * FROM `%s` WHERE %s", c.table.Name, clause)
 	contextData.Statement, err = conn.Prepare(query)
 	return contextData, err
 }

--- a/benchmarks/tutorialbench/workload_read_latest_chirps.go
+++ b/benchmarks/tutorialbench/workload_read_latest_chirps.go
@@ -13,7 +13,7 @@ type ReadLatestChirps struct {
 }
 
 func (w *ReadLatestChirps) Event(ctx mybench.WorkerContext[mybench.NoContextData]) error {
-	query := fmt.Sprintf("SELECT * FROM %s ORDER BY created_at DESC LIMIT 200", w.table.Name)
+	query := fmt.Sprintf("SELECT * FROM `%s` ORDER BY created_at DESC LIMIT 200", w.table.Name)
 	_, err := ctx.Conn.Execute(query)
 	return err
 }

--- a/benchmarks/tutorialbench/workload_read_single_chirp.go
+++ b/benchmarks/tutorialbench/workload_read_single_chirp.go
@@ -25,7 +25,7 @@ func (w *ReadSingleChirp) Event(ctx mybench.WorkerContext[ReadSingleChirpContext
 func (w *ReadSingleChirp) NewContextData(conn *mybench.Connection) (ReadSingleChirpContext, error) {
 	var err error
 	ctx := ReadSingleChirpContext{}
-	ctx.stmt, err = conn.Prepare(fmt.Sprintf("SELECT * FROM %s WHERE id = ?", w.table.Name))
+	ctx.stmt, err = conn.Prepare(fmt.Sprintf("SELECT * FROM `%s` WHERE id = ?", w.table.Name))
 	return ctx, err
 }
 

--- a/data_generators.go
+++ b/data_generators.go
@@ -476,7 +476,7 @@ func NewUniqueStringGeneratorFromDatabase(databaseConfig DatabaseConfig, table, 
 	}
 	defer conn.Close()
 
-	query := fmt.Sprintf("SELECT MIN(CAST(SUBSTRING_INDEX(%s, '!', 1) AS UNSIGNED)) AS min_value, MAX(CAST(SUBSTRING_INDEX(%s, '!', 1) AS UNSIGNED)) AS current_value FROM %s.%s", column, column, databaseConfig.Database, table)
+	query := fmt.Sprintf("SELECT MIN(CAST(SUBSTRING_INDEX(%s, '!', 1) AS UNSIGNED)) AS min_value, MAX(CAST(SUBSTRING_INDEX(%s, '!', 1) AS UNSIGNED)) AS current_value FROM `%s`.`%s`", column, column, databaseConfig.Database, table)
 	res, err := conn.Execute(query)
 	if err != nil {
 		return nil, err
@@ -492,7 +492,7 @@ func NewUniqueStringGeneratorFromDatabase(databaseConfig DatabaseConfig, table, 
 		return nil, err
 	}
 
-	query = fmt.Sprintf("SELECT LENGTH(`%s`) FROM %s.%s LIMIT 1", column, databaseConfig.Database, table)
+	query = fmt.Sprintf("SELECT LENGTH(`%s`) FROM `%s`.`%s` LIMIT 1", column, databaseConfig.Database, table)
 	res, err = conn.Execute(query)
 	if err != nil {
 		return nil, err
@@ -694,7 +694,7 @@ func NewAutoIncrementGeneratorFromDatabase(databaseConfig DatabaseConfig, table,
 	}
 	defer conn.Close()
 
-	query := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s.%s", column, column, databaseConfig.Database, table)
+	query := fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM`%s`.`%s`", column, column, databaseConfig.Database, table)
 	res, err := conn.Execute(query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

Since they are not escaped with `, values with a dash or space will not work. This fixes it.