### PR TITLE
ci(si-2496): Migrate to shop/setup-python-action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,8 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
+      - name: Set up Python
+        uses: shop/setup-python-action@main
+
       - name: Install dependencies
-        run: sudo pip3 install "sphinx~=5.3"
+        # TODO: add sphinx as a dev dependency via uv
+        run: uv pip install "sphinx~=5.3"
 
       - name: Build Sphinx documentation site
         run: make docs


### PR DESCRIPTION
Hey there, we are mitigating #si-2496-remediation 

We expect JavaScript and Python to migrate immediately based on [this recent annoucement](https://my.slack.com/archives/C0Q0DSZR8/p1775767510960779) in [#dev-up][dev-up]

This PR is a best-effort attempt to migrate for you!

* :green_heart: If this passes CI and we think it is a trivial change, we may merge this for you.
* :broken_heart: If this doesn't pass CI or we think it's a non-trivial change, feel free to take over ownership, add commits to it, and do what it takes to merge it.
* :hammer_and_pick: If you have already mitigated it, or are working on it separately, feel free to close this PR with a comment referencing the other PR.

If you need help, reach out in [#dev-up][dev-up]

[dev-up]: https://slack.com/archives/C0Q0DSZR8